### PR TITLE
Dynamic menus

### DIFF
--- a/cmake_files/basic_vars.cmake
+++ b/cmake_files/basic_vars.cmake
@@ -54,6 +54,7 @@ set(CTWMSRC
 	otp.c
 	parse.c
 	parse_be.c
+	parse_menu.c
 	parse_yacc.c
 	r_area.c
 	r_area_list.c

--- a/doc/manual/ctwm.1.adoc
+++ b/doc/manual/ctwm.1.adoc
@@ -2676,6 +2676,10 @@ f.jumpright `step`::
 f.jumpup `step`::
   Upward equivalent of f.jumpdown.
 
+f.label::
+  This function provides a left aligned, unselectable item in a menu
+  definition.  It should not be used in any other context.
+
 f.lefticonmgr::
   This function similar to `f.backiconmgr` except that wrapping does not
   change rows.

--- a/doc/manual/ctwm.1.adoc
+++ b/doc/manual/ctwm.1.adoc
@@ -2523,6 +2523,43 @@ f.downworkspace::
   manager. If the current workspace is the bottom one, goto the top one in the
   same column. The result depends on the layout of the workspace manager.
 
+f.dynmenu `string`::
+  This function invokes a menu created dynamically by the execution of
+  the argument `string` passed to `/bin/sh`. On stdout of this execution,
+  the definition of one or several menu items is expected:
++
+------
+"item1"  [ ("fg1":"bg1") ]  function1
+"item2"  [ ("fg2":"bg2") ]  function2
+    .
+    .
+    .
+"itemN"  [ ("fgN":"bgN") ]  functionN
+------
++
+Example of use:
++
+------
+f.dynmenu "/usr/local/bin/mymenu.sh"
+------
++
+with `/usr/local/bin/mymenu.sh` defined as:
++
+------
+#!/bin/sh
+cat <<EOF
+"$(hostname)" f.title
+"*$(date)"    !"daemon xterm"
+"Details..."  f.dynmenu "/usr/local/bin/another_menu.sh"
+"Pin" ("white":"red") f.pin
+EOF
+------
++
+Note that the script is launched every times `f.dynmenu` is
+invoked. The result is not cached. So if `mymenu.sh` content changes
+at runtime, the resulting menu entries change at the next `f.dynmenu`
+invocation.
+
 f.exec `string`::
   This function passes the argument `string` to `/bin/sh` for execution.
   In multiscreen mode, if `string` starts a new X client without
@@ -2643,7 +2680,7 @@ f.lower::
 
 f.menu `string`::
   This function invokes the menu specified by the argument `string`.
-  Cascaded menus may be built by nesting calls to `f.menu`. When a menu
+  Cascaded menus may be built by nesting calls to `f.menu` or `f.dynmenu`. When a menu
   is popped up, you can use the arrow keys to move the cursor around it. ``Down''
   or space goes down, ``Up'' goes up, ``Left'' pops down the menu, and ``Right''
   activates the current entry. The first letter of an entry name activates this
@@ -3096,6 +3133,8 @@ the corresponding entry will be the default entry for this menu. When a menu
 has a default entry and is used as a submenu of another menu, this default entry
 action will be executed automatically when this submenu is selected without being
 displayed. It's hard to explain, but easy to understand.
+
+See `f.dynmenu` function to dynamically define menus.
 
 === Special Menus
 

--- a/doc/manual/ctwm.1.adoc
+++ b/doc/manual/ctwm.1.adoc
@@ -208,8 +208,24 @@ user-defined menus (containing functions to be invoked or
 commands to be executed).
 
 Variable names and keywords are case-insensitive.  Strings must be
-surrounded by double quote characters (e.g. ``blue'') and are
-case-sensitive.  A pound sign (&#35;) outside of a string causes the
+surrounded by double quote characters (e.g. "blue") and are
+case-sensitive. A string can contain newline characters (useful for
+`f.exec` or `f.dynmenu`), but multiline strings are better achieved
+using triple quoting as in:
+------
+f.dynmenu """
+cat <<EOF
+"$(hostname)" f.title
+"*$(date)"    !"daemon xterm"
+EOF
+"""
+------
+In double quoted strings, classic escape sequences are recognized
+(`\b`, `\f`, `\n`, `\r`, `\t`, octal `\nnn`, hexadecimal `\0xnn` or
+`\xnn`, `\"`, `\'` and `\\`). In multiline strings, no escape
+sequences are allowed.
+
+A pound sign (&#35;) outside of a string or a multiline strings causes the
 remainder of the line in which the character appears to be treated as
 a comment.
 

--- a/event_handlers.c
+++ b/event_handlers.c
@@ -774,8 +774,9 @@ void HandleKeyPress(void)
 		 */
 		if(item) {
 			switch(item->func) {
-				/* f.nop and f.title, we just silently let pass */
+				/* f.label, f.nop and f.title, we just silently let pass */
 				case 0 :
+				case F_LABEL :
 				case F_TITLE :
 					break;
 
@@ -2421,6 +2422,7 @@ void HandleButtonRelease(void)
 			int func = ActiveItem->func;
 			Action = ActiveItem->action;
 			switch(func) {
+				case F_LABEL:
 				case F_TITLE:
 					if(Scr->StayUpMenus)   {
 						ButtonPressed = -1;

--- a/functions.c
+++ b/functions.c
@@ -253,7 +253,7 @@ EF_main(EF_FULLPROTO)
 			MenuItem *mitem;
 			Cursor curs;
 
-			if((mroot = FindMenuRoot(action)) == NULL) {
+			if((mroot = FindMenuRoot(action, false)) == NULL) {
 				if(!action) {
 					action = "undef";
 				}

--- a/functions.c
+++ b/functions.c
@@ -15,6 +15,7 @@
 #include "screen.h"
 
 
+static DFHANDLER(label);
 static DFHANDLER(nop);
 static DFHANDLER(separator);
 static DFHANDLER(title);
@@ -138,6 +139,7 @@ EF_main(EF_FULLPROTO)
 	 * skip out early if we try running them.
 	 */
 	switch(func) {
+		case F_LABEL:
 		case F_NOP:
 		case F_SEPARATOR:
 		case F_TITLE:
@@ -199,6 +201,7 @@ EF_main(EF_FULLPROTO)
 		case F_BACKICONMGR:
 		case F_NEXTICONMGR:
 		case F_PREVICONMGR:
+		case F_LABEL:
 		case F_NOP:
 		case F_TITLE:
 		case F_DELTASTOP:
@@ -491,7 +494,13 @@ NeedToDefer(MenuRoot *root)
  * which we expect to exist.
  */
 
-/* f.nop, f.title, f.separator really only exist to make lines in menus */
+/* f.label, f.nop, f.title, f.separator really only exist to make lines in menus */
+static
+DFHANDLER(label)
+{
+	fprintf(stderr, "%s(): Shouldn't get here.\n", __func__);
+	return;
+}
 static
 DFHANDLER(nop)
 {

--- a/functions_defs.list
+++ b/functions_defs.list
@@ -41,6 +41,7 @@ deltastop             - -  -
 destroy               - CD -
 downiconmgr           - -  -
 downworkspace         - -  -
+dynmenu               S -  -
 exec                  S -  -
 fill                  S CS -
 fittocontent          - CS WINBOX

--- a/functions_defs.list
+++ b/functions_defs.list
@@ -64,6 +64,7 @@ jumpdown              S CM -
 jumpleft              S CM -
 jumpright             S CM -
 jumpup                S CM -
+label                 - -  -
 lefticonmgr           - -  -
 leftworkspace         - -  -
 leftzoom              - CS -

--- a/functions_internal.h
+++ b/functions_internal.h
@@ -160,6 +160,7 @@ DFHANDLER(stopanimation);
 DFHANDLER(speedupanimation);
 DFHANDLER(slowdownanimation);
 DFHANDLER(menu);
+DFHANDLER(dynmenu);
 DFHANDLER(pin);
 DFHANDLER(altkeymap);
 DFHANDLER(altcontext);
@@ -194,5 +195,7 @@ extern Time last_time;
 
 /* Several places need to frob this to leave the cursor alone */
 extern bool func_reset_cursor;
+
+char *Execute(const char *, bool);
 
 #endif /* _CTWM_FUNCTIONS_INTERNAL_H */

--- a/gram.y
+++ b/gram.y
@@ -223,18 +223,18 @@ stmt		: error
 		| RIGHT_TITLEBUTTON string { CreateTitleButton($2, 0, NULL, NULL, true, true); }
 		  binding_list
 		| button string		{
-		    root = GetRoot($2, NULL, NULL);
+		    root = GetRoot($2, NULL, NULL, false);
 		    AddFuncButton ($1, C_ROOT, 0, F_MENU, root, NULL);
 		}
 		| button action		{
-			if ($2 == F_MENU) {
+			if ($2 == F_MENU || $2 == F_DYNMENU) {
 			    pull->prev = NULL;
 			    AddFuncButton ($1, C_ROOT, 0, $2, pull, NULL);
 			}
 			else {
 			    MenuItem *item;
 
-			    root = GetRoot(TWM_ROOT,NULL,NULL);
+			    root = GetRoot(TWM_ROOT,NULL,NULL,false);
 			    item = AddToMenu (root, "x", Action,
 					NULL, $2, NULL, NULL);
 			    AddFuncButton ($1, C_ROOT, 0, $2, NULL, item);
@@ -355,11 +355,11 @@ stmt		: error
 		  win_list
 		| AUTO_LOWER		{ Scr->AutoLowerDefault = true; }
 		| MENU string LP string COLON string RP	{
-					root = GetRoot($2, $4, $6); }
+					root = GetRoot($2, $4, $6, false); }
 		  menu			{ root->real_menu = true;}
-		| MENU string		{ root = GetRoot($2, NULL, NULL); }
+		| MENU string		{ root = GetRoot($2, NULL, NULL, false); }
 		  menu			{ root->real_menu = true; }
-		| FUNCTION string	{ root = GetRoot($2, NULL, NULL); }
+		| FUNCTION string	{ root = GetRoot($2, NULL, NULL, false); }
 		  function
 		| ICONS			{ curplist = &Scr->IconNames; }
 		  icon_list
@@ -370,14 +370,14 @@ stmt		: error
 		| MONOCHROME		{ color = MONOCHROME; }
 		  color_list
 		| DEFAULT_FUNCTION action { Scr->DefaultFunction.func = $2;
-					  if ($2 == F_MENU)
+					  if ($2 == F_MENU || $2 == F_DYNMENU)
 					  {
 					    pull->prev = NULL;
 					    Scr->DefaultFunction.menu = pull;
 					  }
 					  else
 					  {
-					    root = GetRoot(TWM_ROOT,NULL,NULL);
+					    root = GetRoot(TWM_ROOT,NULL,NULL,false);
 					    Scr->DefaultFunction.item =
 						AddToMenu(root,"x",Action,
 							  NULL,$2, NULL, NULL);
@@ -386,7 +386,7 @@ stmt		: error
 					  pull = NULL;
 					}
 		| WINDOW_FUNCTION action { Scr->WindowFunction.func = $2;
-					   root = GetRoot(TWM_ROOT,NULL,NULL);
+					   root = GetRoot(TWM_ROOT,NULL,NULL,false);
 					   Scr->WindowFunction.item =
 						AddToMenu(root,"x",Action,
 							  NULL,$2, NULL, NULL);
@@ -394,7 +394,7 @@ stmt		: error
 					   pull = NULL;
 					}
 		| CHANGE_WORKSPACE_FUNCTION action { Scr->ChangeWorkspaceFunction.func = $2;
-					   root = GetRoot(TWM_ROOT,NULL,NULL);
+					   root = GetRoot(TWM_ROOT,NULL,NULL,false);
 					   Scr->ChangeWorkspaceFunction.item =
 						AddToMenu(root,"x",Action,
 							  NULL,$2, NULL, NULL);
@@ -402,7 +402,7 @@ stmt		: error
 					   pull = NULL;
 					}
 		| DEICONIFY_FUNCTION action { Scr->DeIconifyFunction.func = $2;
-					   root = GetRoot(TWM_ROOT,NULL,NULL);
+					   root = GetRoot(TWM_ROOT,NULL,NULL,false);
 					   Scr->DeIconifyFunction.item =
 						AddToMenu(root,"x",Action,
 							  NULL,$2, NULL, NULL);
@@ -410,7 +410,7 @@ stmt		: error
 					   pull = NULL;
 					}
 		| ICONIFY_FUNCTION action { Scr->IconifyFunction.func = $2;
-					   root = GetRoot(TWM_ROOT,NULL,NULL);
+					   root = GetRoot(TWM_ROOT,NULL,NULL,false);
 					   Scr->IconifyFunction.item =
 						AddToMenu(root,"x",Action,
 							  NULL,$2, NULL, NULL);
@@ -1069,8 +1069,9 @@ action		: FKEYWORD	{ $$ = $1; }
 				$$ = $1;
 				Action = (char*)$2;
 				switch ($1) {
+				  case F_DYNMENU:
 				  case F_MENU:
-				    pull = GetRoot ($2, NULL,NULL);
+				    pull = GetRoot ($2, NULL, NULL, $1 == F_DYNMENU);
 				    pull->prev = root;
 				    break;
 				  case F_WARPRING:

--- a/gram.y
+++ b/gram.y
@@ -97,7 +97,7 @@ int yylex(void);
 %token <num> MONITOR_LAYOUT
 %token <num> RPLAY_SOUNDS
 %token <num> FORCE_FOCUS
-%token <ptr> STRING
+%token <ptr> STRING MLSTRING
 
 %type <ptr> string
 %type <num> action button number signed_number keyaction full fullkey
@@ -1129,6 +1129,7 @@ string		: STRING		{ char *ptr = strdup($1);
 					  RemoveDQuote(ptr);
 					  $$ = ptr;
 					}
+		| MLSTRING		{ $$ = DupUnquoteMultilineString($1); }
 		;
 
 number		: NUMBER		{ $$ = $1; }

--- a/lex.l
+++ b/lex.l
@@ -49,6 +49,7 @@
 %}
 
 string				\"([^"]|\\.)*\"
+mlstring			\"\"\"([^\"]+|\"[^\"]+|\"\"[^\"]+)*\"\"\"
 number				[0-9]+
 
  /* Requires flex 2.5.1 (28Mar95) */
@@ -82,6 +83,7 @@ number				[0-9]+
 "!"				{ yylval.num = F_EXEC; return FSKEYWORD; }
 
 {string}			{ yylval.ptr = yytext; return STRING; }
+{mlstring}			{ yylval.ptr = yytext; return MLSTRING; }
 {number}			{ sscanf(yytext, "%d", &yylval.num);
 				  return NUMBER; }
 \#[^\n]*\n			{;}

--- a/menus.c
+++ b/menus.c
@@ -36,6 +36,7 @@
 #include "events.h"
 #include "functions.h"
 #include "functions_defs.h"
+#include "functions_internal.h"
 #include "gram.tab.h"
 #include "iconmgr.h"
 #include "icons_builtin.h"
@@ -44,6 +45,8 @@
 #include "list.h"
 #include "occupation.h"
 #include "otp.h"
+#include "parse.h"
+#include "parse_menu.h"
 #include "screen.h"
 #ifdef SOUNDS
 #  include "sound.h"
@@ -75,7 +78,6 @@ static bool addingdefaults = false;
 
 static void Paint3DEntry(MenuRoot *mr, MenuItem *mi, bool exposure);
 static void PaintNormalEntry(MenuRoot *mr, MenuItem *mi, bool exposure);
-static void DestroyMenu(MenuRoot *menu);
 
 
 #define SHADOWWIDTH 5                   /* in pixels */
@@ -308,7 +310,7 @@ Paint3DEntry(MenuRoot *mr, MenuItem *mi, bool exposure)
 			}
 		}
 
-		if(mi->func == F_MENU) {
+		if(mi->func == F_MENU || mi->func == F_DYNMENU) {
 			/* create the pull right pixmap if needed */
 			if(Scr->pullPm == None) {
 				Scr->pullPm = Create3DMenuIcon(Scr->EntryHeight - ENTRY_SPACING, &Scr->pullW,
@@ -378,7 +380,7 @@ PaintNormalEntry(MenuRoot *mr, MenuItem *mi, bool exposure)
 				          mr->width, y_offset + Scr->EntryHeight - 1);
 		}
 
-		if(mi->func == F_MENU) {
+		if(mi->func == F_MENU || mi->func == F_DYNMENU) {
 			/* create the pull right pixmap if needed */
 			if(Scr->pullPm == None) {
 				Scr->pullPm = CreateMenuIcon(Scr->MenuFont.height,
@@ -473,7 +475,7 @@ void MakeWorkspacesMenu(void)
 		AddToMenu(Scr->Workspaces, wlist->name, *act, Scr->Windows, F_MENU, NULL, NULL);
 		act++;
 	}
-	Scr->Workspaces->pinned = false;
+	Scr->Workspaces->pinned_from = NULL;
 	MakeMenu(Scr->Workspaces);
 }
 
@@ -583,7 +585,8 @@ void UpdateMenu(void)
 		}
 
 		/* now check to see if we were over the arrow of a pull right entry */
-		if(ActiveItem && ActiveItem->func == F_MENU &&
+		if(ActiveItem && (ActiveItem->func == F_MENU || ActiveItem->func == F_DYNMENU)
+		                &&
 		                ((ActiveMenu->width - x) < (ActiveMenu->width / 3))) {
 			MenuRoot *save = ActiveMenu;
 			int savex = MenuOrigins[MenuDepth - 1].x;
@@ -630,76 +633,66 @@ void UpdateMenu(void)
  *
  *  Inputs:
  *      name    - the name of the menu root
+ *      dynamic - name is a shell command to populate the menu
  *
  ***********************************************************************
  */
 
-MenuRoot *NewMenuRoot(char *name)
+MenuRoot *NewMenuRoot(char *name, bool dynamic)
 {
 	MenuRoot *tmp;
 
 #define UNUSED_PIXEL ((unsigned long) (~0))     /* more than 24 bits */
 
-	tmp = malloc(sizeof(MenuRoot));
+	tmp = calloc(1, sizeof(MenuRoot));
 	tmp->highlight.fore = UNUSED_PIXEL;
 	tmp->highlight.back = UNUSED_PIXEL;
 	tmp->name = name;
-	tmp->prev = NULL;
-	tmp->first = NULL;
-	tmp->last = NULL;
-	tmp->defaultitem = NULL;
-	tmp->items = 0;
-	tmp->width = 0;
 	tmp->mapped = MRM_NEVER;
-	tmp->pull = false;
 	tmp->w = None;
 	tmp->shadow = None;
-	tmp->real_menu = false;
+	tmp->dynamic = dynamic;
 
 	if(Scr->MenuList == NULL) {
 		Scr->MenuList = tmp;
-		Scr->MenuList->next = NULL;
 	}
 
 	if(Scr->LastMenu == NULL) {
 		Scr->LastMenu = tmp;
-		Scr->LastMenu->next = NULL;
 	}
 	else {
 		Scr->LastMenu->next = tmp;
 		Scr->LastMenu = tmp;
-		Scr->LastMenu->next = NULL;
+	}
+
+	if(dynamic) {
+		return tmp;
 	}
 
 	if(strcmp(name, TWM_WINDOWS) == 0) {
 		Scr->Windows = tmp;
 	}
-
-	if(strcmp(name, TWM_ICONS) == 0) {
+	else if(strcmp(name, TWM_ICONS) == 0) {
 		Scr->Icons = tmp;
 	}
-
-	if(strcmp(name, TWM_WORKSPACES) == 0) {
+	else if(strcmp(name, TWM_WORKSPACES) == 0) {
 		Scr->Workspaces = tmp;
 		if(!Scr->Windows) {
-			NewMenuRoot(TWM_WINDOWS);
+			NewMenuRoot(TWM_WINDOWS, false);
 		}
 	}
-	if(strcmp(name, TWM_ALLWINDOWS) == 0) {
+	else if(strcmp(name, TWM_ALLWINDOWS) == 0) {
 		Scr->AllWindows = tmp;
 	}
-
 	/* Added by dl 2004 */
-	if(strcmp(name, TWM_ALLICONS) == 0) {
+	else if(strcmp(name, TWM_ALLICONS) == 0) {
 		Scr->AllIcons = tmp;
 	}
-
 	/* Added by Dan Lilliehorn (dl@dl.nu) 2000-02-29       */
-	if(strcmp(name, TWM_KEYS) == 0) {
+	else if(strcmp(name, TWM_KEYS) == 0) {
 		Scr->Keys = tmp;
 	}
-
-	if(strcmp(name, TWM_VISIBLE) == 0) {
+	else if(strcmp(name, TWM_VISIBLE) == 0) {
 		Scr->Visible = tmp;
 	}
 
@@ -771,7 +764,15 @@ MenuItem *AddToMenu(MenuRoot *menu, char *item, char *action,
 		itemname = item;
 	}
 	else if(*item == '*') {
-		itemname = item + 1;
+		// Dynamic menus are freed, so the item has to point to the
+		// root of the allocated area
+		if(menu->dynamic) {
+			memmove(item, item + 1, strlen(item)); // includes \0
+			itemname = item;
+		}
+		else {
+			itemname = item + 1;
+		}
 		menu->defaultitem = tmp;
 	}
 	else {
@@ -838,11 +839,9 @@ void MakeMenus(void)
 	MenuRoot *mr;
 
 	for(mr = Scr->MenuList; mr != NULL; mr = mr->next) {
-		if(mr->real_menu == false) {
+		if(mr->real_menu == false || mr->dynamic) {
 			continue;
 		}
-
-		mr->pinned = false;
 		MakeMenu(mr);
 	}
 }
@@ -893,7 +892,7 @@ void MakeMenu(MenuRoot *mr)
 			mr->width  += 2 * Scr->MenuShadowDepth;
 			mr->height += 2 * Scr->MenuShadowDepth;
 		}
-		if(Scr->Shadow && ! mr->pinned) {
+		if(Scr->Shadow && ! mr->pinned_from) {
 			/*
 			 * Make sure that you don't draw into the shadow window or else
 			 * the background bits there will get saved
@@ -918,7 +917,7 @@ void MakeMenu(MenuRoot *mr)
 		valuemask = (CWBackPixel | CWBorderPixel | CWEventMask);
 		attributes.background_pixel = Scr->MenuC.back;
 		attributes.border_pixel = Scr->MenuC.fore;
-		if(mr->pinned) {
+		if(mr->pinned_from) {
 			attributes.event_mask = (ExposureMask | EnterWindowMask
 			                         | LeaveWindowMask | ButtonPressMask
 			                         | ButtonReleaseMask | PointerMotionMask
@@ -931,7 +930,7 @@ void MakeMenu(MenuRoot *mr)
 			attributes.event_mask = (ExposureMask | EnterWindowMask);
 		}
 
-		if(Scr->SaveUnder && ! mr->pinned) {
+		if(Scr->SaveUnder && ! mr->pinned_from) {
 			valuemask |= CWSaveUnder;
 			attributes.save_under = True;
 		}
@@ -1022,7 +1021,6 @@ void MakeMenu(MenuRoot *mr)
 			}
 		}
 	}
-	mr->pmenu = NULL;
 
 	if(Scr->Monochrome == MONOCHROME || !Scr->InterpolateMenuColors) {
 		return;
@@ -1113,6 +1111,67 @@ void MakeMenu(MenuRoot *mr)
 }
 
 
+MenuRoot *CopyMenu(MenuRoot *mr, bool deeply)
+{
+	MenuRoot *new;
+	MenuItem *item;
+
+	new = malloc(sizeof(MenuRoot));
+	*new = *mr;
+
+	if(!deeply) {
+		return new;
+	}
+
+	if(new->first == NULL) {
+		return new;
+	}
+	new->first = NULL;
+
+	for(item = mr->first; item != NULL; item = item->next) {
+		MenuItem *new_item = malloc(sizeof(MenuItem));
+		*new_item = *item;
+		item->item = strdup(item->item);
+		if(item->action != NULL) {
+			item->action = strdup(item->action);
+		}
+
+		new_item->root = new;
+		if(new->first == NULL) {
+			new->first = new_item;
+			new_item->prev = NULL;
+		}
+		else {
+			new_item->prev = new->last;
+			new_item->prev->next = new_item;
+		}
+		new->last = new_item;
+
+		if(mr->defaultitem == item) {
+			new->defaultitem = new_item;
+		}
+		if(mr->lastactive == item) {
+			new->lastactive = new_item;
+		}
+	}
+
+	return new;
+}
+
+
+void
+PopulateDynamicMenu(MenuRoot *mr)
+{
+	DestroyMenu(mr, true);
+
+	char *src = Execute(mr->name, true);
+	if(src != NULL) {
+		ParseMenu(mr, src);
+		free(src);
+	}
+}
+
+
 /***********************************************************************
  *
  *  Procedure:
@@ -1159,15 +1218,8 @@ PopUpMenu(MenuRoot *menu, int x, int y, bool center)
 		icons = (menu == Scr->Icons);
 		visible_ = (menu == Scr->Visible);    /* Added by dl */
 		allicons = (menu == Scr->AllIcons);
-		DestroyMenu(menu);
+		DestroyMenu(menu, false);
 
-		menu->first = NULL;
-		menu->last = NULL;
-		menu->items = 0;
-		menu->width = 0;
-		menu->mapped = MRM_NEVER;
-		menu->highlight.fore = UNUSED_PIXEL;
-		menu->highlight.back = UNUSED_PIXEL;
 		if(menu == Scr->Windows) {
 			AddToMenu(menu, "TWM Windows", NULL, NULL, F_TITLE, NULL, NULL);
 		}
@@ -1297,25 +1349,16 @@ PopUpMenu(MenuRoot *menu, int x, int y, bool center)
 		}
 		free(WindowNames);
 
-		menu->pinned = false;
+		menu->pinned_from = NULL;
+		menu->pmenu = NULL;
 		MakeMenu(menu);
 	}
-
 	/* Keys added by dl */
-
-	if(menu == Scr->Keys) {
+	else if(menu == Scr->Keys) {
 		char *oldact = 0;
 		int oldmod = 0;
 
-		DestroyMenu(menu);
-
-		menu->first = NULL;
-		menu->last = NULL;
-		menu->items = 0;
-		menu->width = 0;
-		menu->mapped = MRM_NEVER;
-		menu->highlight.fore = UNUSED_PIXEL;
-		menu->highlight.back = UNUSED_PIXEL;
+		DestroyMenu(menu, false);
 
 		AddToMenu(menu, "Twm Keys", NULL, NULL, F_TITLE, NULL, NULL);
 
@@ -1339,15 +1382,26 @@ PopUpMenu(MenuRoot *menu, int x, int y, bool center)
 			oldact = tmpKey->action;
 			oldmod = tmpKey->mods;
 		}
-		menu->pinned = false;
+		menu->pinned_from = NULL;
+		menu->pmenu = NULL;
 		MakeMenu(menu);
-	}
-	if(menu->w == None || menu->items == 0) {
-		return false;
 	}
 
 	/* Prevent recursively bringing up menus. */
-	if((!menu->pinned) && (menu->mapped == MRM_MAPPED)) {
+	if((!menu->pinned_from) && (menu->mapped == MRM_MAPPED)) {
+		return false;
+	}
+
+	if(menu->dynamic) {
+		PopulateDynamicMenu(menu);
+		if(menu->items == 0) {
+			return false;
+		}
+		// Do not reset menu->pmenu, a pinned menu is perhaps present
+		MakeMenu(menu);
+	}
+
+	if(menu->w == None || menu->items == 0) {
 		return false;
 	}
 
@@ -1357,7 +1411,7 @@ PopUpMenu(MenuRoot *menu, int x, int y, bool center)
 	 */
 	menu->prev = ActiveMenu;
 
-	if(menu->pinned) {
+	if(menu->pinned_from) {
 		ActiveMenu    = menu;
 		menu->mapped  = MRM_MAPPED;
 		menu->entered = true;
@@ -1453,7 +1507,7 @@ void PopDownMenu(void)
 	}
 
 	for(tmp = ActiveMenu; tmp != NULL; tmp = tmp->prev) {
-		if(! tmp->pinned) {
+		if(! tmp->pinned_from) {
 			HideMenu(tmp);
 		}
 		UninstallRootColormap();
@@ -1496,16 +1550,17 @@ void HideMenu(MenuRoot *menu)
  *
  *  Inputs:
  *      name    - the name of the menu root
+ *      dynamic - the menu is dynamic
  *
  ***********************************************************************
  */
 
-MenuRoot *FindMenuRoot(char *name)
+MenuRoot *FindMenuRoot(char *name, bool dynamic)
 {
 	MenuRoot *tmp;
 
 	for(tmp = Scr->MenuList; tmp != NULL; tmp = tmp->next) {
-		if(strcmp(name, tmp->name) == 0) {
+		if(tmp->dynamic == dynamic && strcmp(name, tmp->name) == 0) {
 			return (tmp);
 		}
 	}
@@ -1514,7 +1569,7 @@ MenuRoot *FindMenuRoot(char *name)
 
 
 
-static void DestroyMenu(MenuRoot *menu)
+void DestroyMenu(MenuRoot *menu, bool full)
 {
 	MenuItem *item;
 
@@ -1525,13 +1580,30 @@ static void DestroyMenu(MenuRoot *menu)
 			XDestroyWindow(dpy, menu->shadow);
 		}
 		XDestroyWindow(dpy, menu->w);
+		menu->w = None;
 	}
 
 	for(item = menu->first; item;) {
 		MenuItem *tmp = item;
 		item = item->next;
+		if(full) {
+			if(tmp->item != NULL) {
+				free(tmp->item);
+			}
+			if(tmp->action != NULL) {
+				free(tmp->action);
+			}
+		}
 		free(tmp);
 	}
+
+	menu->items = 0;
+	menu->width = 0;
+	menu->mapped = MRM_NEVER;
+	menu->highlight.fore = UNUSED_PIXEL;
+	menu->highlight.back = UNUSED_PIXEL;
+
+	menu->first = menu->last = menu->lastactive = menu->defaultitem = NULL;
 }
 
 
@@ -1546,7 +1618,7 @@ void MoveMenu(XEvent *eventp)
 	if(! ActiveMenu) {
 		return;
 	}
-	if(! ActiveMenu->pinned) {
+	if(! ActiveMenu->pinned_from) {
 		return;
 	}
 

--- a/menus.c
+++ b/menus.c
@@ -272,7 +272,7 @@ Paint3DEntry(MenuRoot *mr, MenuItem *mi, bool exposure)
 		int x, y;
 
 		gc = Scr->NormalGC;
-		if(mi->state) {
+		if(mi->state && mi->func != F_LABEL) {
 			Draw3DBorder(mr->w, Scr->MenuShadowDepth, y_offset,
 			             mr->width - 2 * Scr->MenuShadowDepth, Scr->EntryHeight, 1,
 			             mi->highlight, off, true, false);
@@ -349,7 +349,7 @@ PaintNormalEntry(MenuRoot *mr, MenuItem *mi, bool exposure)
 	if(mi->func != F_TITLE) {
 		int x, y;
 
-		if(mi->state) {
+		if(mi->state && mi->func != F_LABEL) {
 			XSetForeground(dpy, Scr->NormalGC, mi->highlight.back);
 
 			XFillRectangle(dpy, mr->w, Scr->NormalGC, 0, y_offset,
@@ -541,7 +541,7 @@ void UpdateMenu(void)
 
 		if(x < 0 || y < 0 ||
 		                x >= ActiveMenu->width || y >= ActiveMenu->height) {
-			if(ActiveItem && ActiveItem->func != F_TITLE) {
+			if(ActiveItem && ActiveItem->func != F_TITLE && ActiveItem->func != F_LABEL) {
 				ActiveItem->state = false;
 				PaintEntry(ActiveMenu, ActiveItem, false);
 			}
@@ -567,7 +567,7 @@ void UpdateMenu(void)
 			/* if we weren't on the active entry, let's turn the old
 			 * active one off
 			 */
-			if(!done && ActiveItem->func != F_TITLE) {
+			if(!done && ActiveItem->func != F_TITLE && ActiveItem->func != F_LABEL) {
 				ActiveItem->state = false;
 				PaintEntry(ActiveMenu, ActiveItem, false);
 			}
@@ -578,7 +578,8 @@ void UpdateMenu(void)
 		 */
 		if(!done) {
 			ActiveItem = mi;
-			if(ActiveItem && ActiveItem->func != F_TITLE && !ActiveItem->state) {
+			if(ActiveItem && ActiveItem->func != F_TITLE && ActiveItem->func != F_LABEL
+			                && !ActiveItem->state) {
 				ActiveItem->state = true;
 				PaintEntry(ActiveMenu, ActiveItem, false);
 			}

--- a/menus.h
+++ b/menus.h
@@ -82,7 +82,8 @@ struct MenuRoot {
 	bool  entered;              /* EnterNotify following pop up */
 	bool  real_menu;            /* this is a real menu */
 	short x, y;                 /* position (for pinned menus) */
-	bool  pinned;               /* is this a pinned menu*/
+	bool  dynamic;              /* is this a dynamic menu */
+	struct MenuRoot *pinned_from; /* pinned menu issued from this one */
 	struct MenuRoot *pmenu;     /* the associated pinned menu */
 };
 
@@ -90,8 +91,8 @@ struct MenuRoot {
 struct MouseButton {
 	int func;                   /* the function number */
 	int mask;                   /* modifier mask */
-	MenuRoot *menu;             /* menu if func is F_MENU */
-	MenuItem *item;             /* action to perform if func != F_MENU */
+	MenuRoot *menu;             /* menu if func is F_MENU|F_DYNMENU */
+	MenuItem *item;             /* action to perform if func != F_MENU|F_DYNMENU */
 };
 
 struct FuncButton {
@@ -100,8 +101,8 @@ struct FuncButton {
 	int cont;                   /* context */
 	int mods;                   /* modifiers */
 	int func;                   /* the function number */
-	MenuRoot *menu;             /* menu if func is F_MENU */
-	MenuItem *item;             /* action to perform if func != F_MENU */
+	MenuRoot *menu;             /* menu if func is F_MENU|F_DYNMENU */
+	MenuItem *item;             /* action to perform if func != F_MENU|F_DYNMENU */
 };
 
 struct FuncKey {
@@ -114,7 +115,7 @@ struct FuncKey {
 	int func;                   /* function to perform */
 	char *win_name;             /* window name (if any) */
 	char *action;               /* action string (if any) */
-	MenuRoot *menu;             /* menu if func is F_MENU */
+	MenuRoot *menu;             /* menu if func is F_MENU|F_DYNMENU */
 };
 
 extern MenuRoot *ActiveMenu;
@@ -136,12 +137,12 @@ extern int MenuDepth;
 #define COLORMAP_PREV "prev"
 #define COLORMAP_DEFAULT "default"
 
-MenuRoot *NewMenuRoot(char *name);
+MenuRoot *NewMenuRoot(char *name, bool dynamic);
 MenuItem *AddToMenu(MenuRoot *menu, char *item, char *action,
                     MenuRoot *sub, int func, char *fore, char *back);
 bool PopUpMenu(MenuRoot *menu, int x, int y, bool center);
 void MakeWorkspacesMenu(void);
-MenuRoot *FindMenuRoot(char *name);
+MenuRoot *FindMenuRoot(char *name, bool dynamic);
 bool AddFuncKey(char *name, int cont, int mods, int func,
                 MenuRoot *menu, char *win_name, char *action);
 void AddFuncButton(int num, int cont, int mods, int func,
@@ -155,6 +156,9 @@ bool cur_fromMenu(void);
 void UpdateMenu(void);
 void MakeMenus(void);
 void MakeMenu(MenuRoot *mr);
+void PopulateDynamicMenu(MenuRoot *mr);
+void DestroyMenu(MenuRoot *mr, bool full);
+MenuRoot *CopyMenu(MenuRoot *mr, bool deeply);
 void MoveMenu(XEvent *eventp);
 void WarpCursorToDefaultEntry(MenuRoot *menu);
 

--- a/parse.c
+++ b/parse.c
@@ -94,6 +94,8 @@ bool ParseError;                        /* error parsing the .twmrc file */
 int RaiseDelay = 0;                     /* msec, for AutoRaise */
 int (*twmInputFunc)(void);              /* used in lexer */
 
+extern int yylex_destroy(void);
+
 static int twmrc_lineno;
 
 
@@ -323,6 +325,8 @@ doparse(int (*ifunc)(void), const char *srctypename,
 #endif
 
 	yyparse();
+
+	yylex_destroy();
 
 	if(ParseError) {
 		fprintf(stderr, "%s:  errors found in twm %s",

--- a/parse_menu.c
+++ b/parse_menu.c
@@ -1,0 +1,237 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "parse_menu.h"
+#include "functions_defs.h"
+#include "gram.tab.h"
+#include "parse_yacc.h"
+
+#ifndef YYEOF
+# define YYEOF 0
+#endif
+
+extern int (*twmInputFunc)(void);
+extern int yylex(void);
+extern int yylex_destroy(void);
+extern char *yytext;
+
+static bool
+ParseMenuEntry(MenuRoot *menu)
+{
+	/* grammar:
+	     action:       FKEYWORD
+	                 | FSKEYWORD STRING
+	     menu_entry:   STRING action
+	                 | STRING LP STRING COLON STRING RP action
+	*/
+#define STEP_START        0
+#define STEP_LABEL_OK     1 // label OK
+#define STEP_LP_OK        2 // "(" OK
+#define STEP_FORE_OK      3 // foreground color OK
+#define STEP_COLON_OK     4 // ":" OK
+#define STEP_BACK_OK      5 // background color OK
+#define STEP_RP_OK        6 // ")" OK
+#define STEP_FSKEYWORD_OK 7 // action FSKEYWORD OK
+#define STEP_DONE         8 // menu entry completed
+#define STEP_ERROR        9 // an error occurred
+	int step = STEP_START;
+
+	char *str, *label = NULL, *fore = NULL, *back = NULL, *action = NULL;
+	MenuRoot *pullm = NULL;
+	int func;
+
+	while(step != STEP_DONE && step != STEP_ERROR) {
+		int token = yylex();
+		switch(token) {
+			case YYEOF:
+				if(step == STEP_START) {
+					return 0;
+				}
+				fprintf(stderr, "Unterminated menu entry (step %d)\n", step);
+				step = STEP_ERROR;
+				break;
+
+			case STRING:
+				str = strdup(yylval.ptr);
+				RemoveDQuote(str);
+				switch(step) {
+					case STEP_START:
+						label = str;
+						step = STEP_LABEL_OK;
+						break;
+					case STEP_LP_OK:
+						fore = str;
+						step = STEP_FORE_OK;
+						break;
+					case STEP_COLON_OK:
+						back = str;
+						step = STEP_BACK_OK;
+						break;
+					case STEP_FSKEYWORD_OK:
+						action = str;
+						step = STEP_DONE;
+						switch(func) {
+							case F_MENU:
+							case F_DYNMENU:
+								pullm = GetRoot(action, NULL, NULL, func == F_DYNMENU);
+								pullm->prev = menu;
+								// If the menu has just been created (so its name ==
+								// 1st GetRoot param), dissociate its name from
+								// action, as action will be freed once the current
+								// menu will be destroyed
+								if(pullm->name == action) {
+									pullm->name = strdup(action);
+								}
+								break;
+							case F_WARPRING:
+								if(!CheckWarpRingArg(action)) {
+									fprintf(stderr, "ignoring invalid f.warptoring argument \"%s\"\n", action);
+									free(action);
+									action = NULL;
+									func = F_NOP;
+								}
+								break;
+							case F_WARPTOSCREEN:
+								if(!CheckWarpScreenArg(action)) {
+									fprintf(stderr, "ignoring invalid f.warptoscreen argument \"%s\"\n", action);
+									free(action);
+									action = NULL;
+									func = F_NOP;
+								}
+								break;
+							case F_COLORMAP:
+								if(!CheckColormapArg(action)) {
+									fprintf(stderr, "ignoring invalid f.colormap argument \"%s\"\n", action);
+									free(action);
+									action = NULL;
+									func = F_NOP;
+								}
+								break;
+						}
+						break;
+					default:
+						free(str);
+						fprintf(stderr, "Unexpected menuentry string \"%s\" (step %d)\n", yylval.ptr,
+						        step);
+						step = STEP_ERROR;
+						break;
+				}
+				break;
+
+			case FKEYWORD:
+				switch(step) {
+					case STEP_LABEL_OK:
+					case STEP_RP_OK:
+						func = yylval.num;
+						step = STEP_DONE;
+						break;
+					default:
+						fprintf(stderr, "Unexpected menuentry keyword %s (step %d)\n", yytext, step);
+						step = STEP_ERROR;
+						break;
+				}
+				break;
+
+			case FSKEYWORD:
+				switch(step) {
+					case STEP_LABEL_OK:
+					case STEP_RP_OK:
+						func = yylval.num;
+						step = STEP_FSKEYWORD_OK;
+						break;
+					default:
+						fprintf(stderr, "Unexpected menuentry keyword %s (step %d)\n", yytext, step);
+						step = STEP_ERROR;
+						break;
+				}
+				break;
+
+			case LP:
+				if(step == STEP_LABEL_OK) {
+					step = STEP_LP_OK;
+					break;
+				}
+				fprintf(stderr, "Unexpected menuentry '(' (step %d)\n", step);
+				step = STEP_ERROR;
+				break;
+
+			case COLON:
+				if(step == STEP_FORE_OK) {
+					step = STEP_COLON_OK;
+					break;
+				}
+				fprintf(stderr, "Unexpected menuentry ':' (step %d)\n", step);
+				step = STEP_ERROR;
+				break;
+
+			case RP:
+				if(step == STEP_BACK_OK) {
+					step = STEP_RP_OK;
+					break;
+				}
+				fprintf(stderr, "Unexpected menuentry ')' (step %d)\n", step);
+				step = STEP_ERROR;
+				break;
+
+			default:
+				fprintf(stderr, "Unexpected menu entry token: \"%s\" / %d (step %d)\n", yytext,
+				        token, step);
+				step = STEP_ERROR;
+				break;
+		}
+	}
+
+	if(step == STEP_ERROR) {
+		if(label != NULL) {
+			free(label);
+		}
+		if(action != NULL) {
+			free(action);
+		}
+		if(fore != NULL) {
+			free(fore);
+		}
+		if(back != NULL) {
+			free(back);
+		}
+		return 0;
+	}
+
+	if(func == F_SEPARATOR) {
+		if(menu->last != NULL) {
+			menu->last->separated = true;
+		}
+	}
+	else {
+		AddToMenu(menu, label, action, pullm, func, fore, back);
+	}
+	if(fore != NULL) {
+		free(fore);
+		free(back);
+	}
+	return 1;
+}
+
+
+static char *currentString;
+static int stringInput(void)
+{
+	if(currentString) {
+		return (unsigned int) * currentString++;
+	}
+	return 0;
+}
+
+
+void
+ParseMenu(MenuRoot *menu, char *src)
+{
+	currentString = src;
+	twmInputFunc = stringInput;
+
+	while(ParseMenuEntry(menu))
+		;
+
+	yylex_destroy();
+	currentString = NULL;
+}

--- a/parse_menu.c
+++ b/parse_menu.c
@@ -15,6 +15,17 @@ extern int yylex(void);
 extern int yylex_destroy(void);
 extern char *yytext;
 
+static char *
+strdupunquote(char *s, bool multiline)
+{
+	if(multiline) {
+		return DupUnquoteMultilineString(s);
+	}
+	s = strdup(s);
+	RemoveDQuote(s);
+	return s;
+}
+
 static bool
 ParseMenuEntry(MenuRoot *menu)
 {
@@ -51,9 +62,9 @@ ParseMenuEntry(MenuRoot *menu)
 				step = STEP_ERROR;
 				break;
 
+			case MLSTRING:
 			case STRING:
-				str = strdup(yylval.ptr);
-				RemoveDQuote(str);
+				str = strdupunquote(yylval.ptr, token == MLSTRING);
 				switch(step) {
 					case STEP_START:
 						label = str;

--- a/parse_menu.h
+++ b/parse_menu.h
@@ -1,0 +1,9 @@
+#ifndef _CTWM_PARSE_MENU_H_
+#define _CTWM_PARSE_MENU_H_
+
+#include "ctwm.h"
+#include "menus.h"
+
+void ParseMenu(MenuRoot *menu, char *src);
+
+#endif  /* _CTWM_PARSE_MENU_H_ */

--- a/parse_yacc.c
+++ b/parse_yacc.c
@@ -8,6 +8,7 @@
 #include "ctwm.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 
@@ -130,6 +131,19 @@ hex:
 		}
 	}
 	*o = '\0';
+}
+
+char *DupUnquoteMultilineString(char *str)
+{
+	char *ret;
+	int len;
+
+	str += 3;
+	len = strlen(str) - 3;
+	ret = malloc(len + 1);
+	memcpy(ret, str, len);
+	ret[len] = '\0';
+	return ret;
 }
 
 MenuRoot *GetRoot(char *name, char *fore, char *back, bool dynamic)

--- a/parse_yacc.c
+++ b/parse_yacc.c
@@ -132,13 +132,13 @@ hex:
 	*o = '\0';
 }
 
-MenuRoot *GetRoot(char *name, char *fore, char *back)
+MenuRoot *GetRoot(char *name, char *fore, char *back, bool dynamic)
 {
 	MenuRoot *tmp;
 
-	tmp = FindMenuRoot(name);
+	tmp = FindMenuRoot(name, dynamic);
 	if(tmp == NULL) {
-		tmp = NewMenuRoot(name);
+		tmp = NewMenuRoot(name, dynamic);
 	}
 
 	if(fore) {
@@ -164,12 +164,13 @@ void GotButton(int butt, int func)
 			continue;
 		}
 
-		if(func == F_MENU) {
+		if(func == F_MENU || func == F_DYNMENU) {
 			pull->prev = NULL;
 			AddFuncButton(butt, i, mods, func, pull, NULL);
 		}
 		else {
-			root = GetRoot(TWM_ROOT, NULL, NULL);
+
+			root = GetRoot(TWM_ROOT, NULL, NULL, false);
 			item = AddToMenu(root, "x", Action, NULL, func, NULL, NULL);
 			AddFuncButton(butt, i, mods, func, NULL, item);
 		}
@@ -191,7 +192,7 @@ void GotKey(char *key, int func)
 			continue;
 		}
 
-		if(func == F_MENU) {
+		if(func == F_MENU || func == F_DYNMENU) {
 			pull->prev = NULL;
 			if(!AddFuncKey(key, i, mods, func, pull, Name, Action)) {
 				break;

--- a/parse_yacc.h
+++ b/parse_yacc.h
@@ -9,7 +9,7 @@ void yyerror(char *s);
 void InitGramVariables(void);
 void RemoveDQuote(char *str);
 
-MenuRoot *GetRoot(char *name, char *fore, char *back);
+MenuRoot *GetRoot(char *name, char *fore, char *back, bool dynamic);
 
 bool CheckWarpScreenArg(const char *s);
 bool CheckWarpRingArg(const char *s);

--- a/parse_yacc.h
+++ b/parse_yacc.h
@@ -8,6 +8,7 @@ void yyerror(char *s);
 
 void InitGramVariables(void);
 void RemoveDQuote(char *str);
+char *DupUnquoteMultilineString(char *str);
 
 MenuRoot *GetRoot(char *name, char *fore, char *back, bool dynamic);
 


### PR DESCRIPTION
- Introduce `f.label` function, a left aligned unselectable menu item
- Introduce multiline strings using triple double-quoting
- Introduce `f.dynmenu` function and so dynamic menus

Example of use with these 3 features mixed together:

```
f.dynmenu """
cat <<EOF
"$(hostname)"                    f.title
"*$(date)"                       !"daemon xterm"
"Details..."                     f.dynmenu "/usr/local/bin/another_menu.sh"
"Battery level $(battery level)" f.label
"Another info $(get_info)"       f.label
"Shutdown" ("white":"red")       !"shutdown -r now"
EOF
"""
```